### PR TITLE
Fixed meson introspect method call

### DIFF
--- a/meson2ide.py
+++ b/meson2ide.py
@@ -108,14 +108,14 @@ def collect_meson_files(src_dir):
     return meson_files
 
 
-def mesonintrospect(commands, build_dir):
-    args = ['meson', 'introspect']
-    args.extend(commands)
-    return subprocess.check_output(args, stderr=subprocess.STDOUT, cwd=build_dir)
+def mesonintrospect(arguments):
+    command = ['meson', 'introspect']
+    command.extend(arguments)
+    return subprocess.check_output(command, stderr=subprocess.STDOUT)
 
 
 def get_project_name(build_dir):
-    info = json.loads(mesonintrospect(['--projectinfo'], build_dir))
+    info = json.loads(mesonintrospect(['--projectinfo', build_dir]))
     return info['name']
 
 


### PR DESCRIPTION
Bug:
Traceback (most recent call last):
  File "meson2ide.py", line 208, in <module>
    main()
  File "meson2ide.py", line 200, in main
    print(get_project_name(build_dir))
  File "meson2ide.py", line 118, in get_project_name
    info = json.loads(mesonintrospect(['--projectinfo'], build_dir))
  File "meson2ide.py", line 114, in mesonintrospect
    return subprocess.check_output(args, stderr=subprocess.STDOUT, cwd=build_dir)
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['meson', 'introspect', '--projectinfo']' returned non-zero exit status 1.

How to reproduce:
python3 meson2ide.py builddir

Environment:
OS: Ubuntu 18.04
Python Version: 3.6
Meson Version: 0.45
